### PR TITLE
Add preliminary CI

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -3,10 +3,7 @@ on:
   push:
     branches:
     - main
-    - feature-add-ci
   pull_request:
-    branches-ignore:
-    - documentation
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -68,6 +68,7 @@ jobs:
       matrix:
         config-name:
           - nvhpc-gpu-cuda-DP
+          - nvhpc-gpu-cuda-SP
     steps:
     #
     # Build, run and check (fetch the log)

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -21,4 +21,5 @@
     #
     # Build libraries
     #
+    - git branch
     - make libs

--- a/.gitlab/levante.yml
+++ b/.gitlab/levante.yml
@@ -25,7 +25,7 @@ variables:
   variables:
     # Core variables:
     FC: /sw/spack-levante/nvhpc-22.5-v4oky3/Linux_x86_64/22.5/compilers/bin/nvfortran
-    CPPC: /sw/spack-levante/nvhpc-22.5-v4oky3/Linux_x86_64/22.5/compilers/bin/nvc++
+    CXX: /sw/spack-levante/nvhpc-22.5-v4oky3/Linux_x86_64/22.5/compilers/bin/nvc++
     # Convenience variables:
     VERSION_FCFLAGS: --version
     NFHOME: /sw/spack-levante/netcdf-fortran-4.5.4-syv4qr

--- a/.gitlab/levante.yml
+++ b/.gitlab/levante.yml
@@ -25,7 +25,7 @@ variables:
   variables:
     # Core variables:
     FC: nvfortran
-    CXX: nvc++
+    CUDACXX: nvcc
     # Convenience variables:
     VERSION_FCFLAGS: --version
     NFHOME: /sw/spack-levante/netcdf-fortran-4.5.4-syv4qr

--- a/.gitlab/levante.yml
+++ b/.gitlab/levante.yml
@@ -55,3 +55,8 @@ nvhpc-gpu-cuda-DP:
   extends:
     - .dp
     - .nvhpc-gpu-openacc
+
+nvhpc-gpu-cuda-SP: 
+  extends:
+    - .sp
+    - .nvhpc-gpu-openacc

--- a/.gitlab/levante.yml
+++ b/.gitlab/levante.yml
@@ -24,14 +24,9 @@ variables:
 .nvhpc:
   variables:
     # Core variables:
-    FC: nvfortran
     CUDACXX: nvcc
     # Flags used in building Icon 
     CUDAFLAGS: -Xptxas -O3 -DNDEBUG -DRTE_RRTMGP_GPU_MEMPOOL_CUDA
-    # Convenience variables:
-    VERSION_FCFLAGS: --version
-    NFHOME: /sw/spack-levante/netcdf-fortran-4.5.4-syv4qr
-    NCHOME: /sw/spack-levante/netcdf-c-4.9.0-gc7kgj
 
 .common-levante:
   extends: .common
@@ -40,13 +35,10 @@ variables:
     # Suppress an irrelevant but annoying error message:
     PROJ_LIB: ${PYHOME}/share/proj
     # Make variables:
-    FCINCLUDE: -I${NFHOME}/include
-    LDFLAGS: -L${NFHOME}/lib -L${NCHOME}/lib
   before_script:
     - module purge
     - module load git
-    - module load gcc/11.2.0-gcc-11.2.0 
-    - module load nvhpc/22.5-gcc-11.2.0
+    - module load nvhpc/24.7-gcc-11.2.0
     # Extend the existing environment variables:
     - export PATH="${PYHOME}/bin:${PATH}"
     - export LD_LIBRARY_PATH="${NFHOME}/lib:${NCHOME}/lib:${LD_LIBRARY_PATH-}"
@@ -58,10 +50,6 @@ variables:
     - .gpu
     - .nvhpc
     - .common-levante
-  variables:
-    # Compiler flags used for ICON model:
-    FCFLAGS: -g -O2 -Mrecursive -Mallocatable=03 -Mstack_arrays -Minfo=accel,inline -acc=gpu,verystrict -gpu=cc80,cuda11.7 -DRTE_USE_${FPMODEL}
-    RTE_KERNELS: accel
 
 nvhpc-gpu-cuda-DP: 
   extends:

--- a/.gitlab/levante.yml
+++ b/.gitlab/levante.yml
@@ -26,6 +26,8 @@ variables:
     # Core variables:
     FC: nvfortran
     CUDACXX: nvcc
+    # Flags used in building Icon 
+    CUDAFLAGS: -arch=sm_80 -g -O3 -expt-relaxed-constexpr -DNDEBUG
     # Convenience variables:
     VERSION_FCFLAGS: --version
     NFHOME: /sw/spack-levante/netcdf-fortran-4.5.4-syv4qr

--- a/.gitlab/levante.yml
+++ b/.gitlab/levante.yml
@@ -24,8 +24,8 @@ variables:
 .nvhpc:
   variables:
     # Core variables:
-    FC: /sw/spack-levante/nvhpc-22.5-v4oky3/Linux_x86_64/22.5/compilers/bin/nvfortran
-    CXX: /sw/spack-levante/nvhpc-22.5-v4oky3/Linux_x86_64/22.5/compilers/bin/nvc++
+    FC: nvfortran
+    CXX: nvc++
     # Convenience variables:
     VERSION_FCFLAGS: --version
     NFHOME: /sw/spack-levante/netcdf-fortran-4.5.4-syv4qr
@@ -43,6 +43,7 @@ variables:
   before_script:
     - module purge
     - module load git
+    - module load nvhpc/22.5-gcc-11.2.0
     # Extend the existing environment variables:
     - export PATH="${PYHOME}/bin:${PATH}"
     - export LD_LIBRARY_PATH="${NFHOME}/lib:${NCHOME}/lib:${LD_LIBRARY_PATH-}"

--- a/.gitlab/levante.yml
+++ b/.gitlab/levante.yml
@@ -27,7 +27,7 @@ variables:
     FC: nvfortran
     CUDACXX: nvcc
     # Flags used in building Icon 
-    CUDAFLAGS: -arch=sm_80 -g -O3 -expt-relaxed-constexpr -DNDEBUG
+    CUDAFLAGS: -Xptxas -O3 -DNDEBUG -DRTE_RRTMGP_GPU_MEMPOOL_CUDA
     # Convenience variables:
     VERSION_FCFLAGS: --version
     NFHOME: /sw/spack-levante/netcdf-fortran-4.5.4-syv4qr

--- a/.gitlab/levante.yml
+++ b/.gitlab/levante.yml
@@ -43,6 +43,7 @@ variables:
   before_script:
     - module purge
     - module load git
+    - module load gcc/11.2.0-gcc-11.2.0 
     - module load nvhpc/22.5-gcc-11.2.0
     # Extend the existing environment variables:
     - export PATH="${PYHOME}/bin:${PATH}"

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/env make
 all:           librtecudakernels.a librrtmgpcudakernels.a
 
-CUDAFLAGS ?= "-O3 -gopt -DRTE_RRTMGP_GPU_MEMPOOL_CUDA -acc -cuda"
+CUDAFLAGS ?= "-Xptxas -O3 -DNDEBUG -DRTE_RRTMGP_GPU_MEMPOOL_CUDA"
 COMPILE_CU = $(CUDACXX) -c $(CUDAFLAGS)
 
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,16 +1,9 @@
 #!/usr/bin/env make
-
-#
-# Compiler variables FC, FCFLAGS must be set in the environment
-#
-# Make all the libraries though we'll only use the interface + kernels
 all:           librtecudakernels.a librrtmgpcudakernels.a
 
-COMPILE = $(FC) $(FCFLAGS) $(FCINCLUDE) -c
-%.o: %.F90
-	$(COMPILE) $<
+CUDAFLAGS ?= "-O3 -gopt -DRTE_RRTMGP_GPU_MEMPOOL_CUDA -acc -cuda"
+COMPILE_CU = $(CUDACXX) -c $(CUDAFLAGS)
 
-COMPILE_CU = $(CUDACXX) -c -O3 -gopt -DRTE_RRTMGP_GPU_MEMPOOL_CUDA -acc -cuda
 
 %.o: %.cu
 	$(COMPILE_CU) $<

--- a/build/Makefile
+++ b/build/Makefile
@@ -10,7 +10,7 @@ COMPILE = $(FC) $(FCFLAGS) $(FCINCLUDE) -c
 %.o: %.F90
 	$(COMPILE) $<
 
-COMPILE_CU = $(CPPC) -c -std=c++17 -O3 -gopt -DRTE_RRTMGP_GPU_MEMPOOL_CUDA -acc -cuda
+COMPILE_CU = $(CXX) -c -std=c++17 -O3 -gopt -DRTE_RRTMGP_GPU_MEMPOOL_CUDA -acc -cuda
 
 %.o: %.cu
 	$(COMPILE_CU) $<

--- a/build/Makefile
+++ b/build/Makefile
@@ -10,7 +10,7 @@ COMPILE = $(FC) $(FCFLAGS) $(FCINCLUDE) -c
 %.o: %.F90
 	$(COMPILE) $<
 
-COMPILE_CU = $(CXX) -c -std=c++17 -O3 -gopt -DRTE_RRTMGP_GPU_MEMPOOL_CUDA -acc -cuda
+COMPILE_CU = $(CUDACXX) -c -std=c++17 -O3 -gopt -DRTE_RRTMGP_GPU_MEMPOOL_CUDA -acc -cuda
 
 %.o: %.cu
 	$(COMPILE_CU) $<

--- a/build/Makefile
+++ b/build/Makefile
@@ -10,7 +10,7 @@ COMPILE = $(FC) $(FCFLAGS) $(FCINCLUDE) -c
 %.o: %.F90
 	$(COMPILE) $<
 
-COMPILE_CU = $(CUDACXX) -c -std=c++17 -O3 -gopt -DRTE_RRTMGP_GPU_MEMPOOL_CUDA -acc -cuda
+COMPILE_CU = $(CUDACXX) -c -O3 -gopt -DRTE_RRTMGP_GPU_MEMPOOL_CUDA -acc -cuda
 
 %.o: %.cu
 	$(COMPILE_CU) $<


### PR DESCRIPTION
This PR adds the first round of continuous integration - it ensures that the libraries build with NVHPC 24.7 on Levante/ 

Addresses the first task of #1. 